### PR TITLE
Ensure HighD detection keeps recordings separate

### DIFF
--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,7 +1,11 @@
+import subprocess
+import sys
+
 import pytest
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
+pytest.importorskip("scipy")
 
 from scenario_parameter_collection.detection import HighDScenarioDetector
 from scenario_parameter_collection.statistics import estimate_parameter_distributions
@@ -70,6 +74,13 @@ def make_synthetic_tracks() -> pd.DataFrame:
     ]
 
 
+def make_synthetic_recording(recording_id: str) -> pd.DataFrame:
+    tracks = make_synthetic_tracks().copy()
+    tracks["recording_id"] = recording_id
+    tracks["source_file"] = f"{recording_id}_tracks.csv"
+    return tracks
+
+
 def test_detector_finds_car_following_and_lane_change():
     tracks = make_synthetic_tracks()
     detector = HighDScenarioDetector(frame_rate=25.0)
@@ -81,3 +92,44 @@ def test_detector_finds_car_following_and_lane_change():
     stats = estimate_parameter_distributions(events)
     assert stats.counts["car_following"] >= 1
     assert "mean_thw" in stats.parameter_distributions["car_following"]
+
+
+def test_multiple_recordings_do_not_mix_events(tmp_path):
+    recording_a = make_synthetic_recording("recording_a")
+    recording_b = make_synthetic_recording("recording_b")
+    combined = pd.concat([recording_a, recording_b], ignore_index=True)
+
+    detector = HighDScenarioDetector(frame_rate=25.0)
+    events = detector.detect(combined)
+    car_following_events = [event for event in events if event.scenario == "car_following"]
+    assert len(car_following_events) == 2
+    assert {event.track_id for event in car_following_events} == {1}
+    assert {(event.start_frame, event.end_frame) for event in car_following_events} == {(0, 49)}
+
+    # Write each recording to its own CSV file and run the CLI
+    input_dir = tmp_path / "recordings"
+    input_dir.mkdir()
+    for df in (recording_a, recording_b):
+        file_name = df["source_file"].iloc[0]
+        df.to_csv(input_dir / file_name, index=False)
+
+    output_dir = tmp_path / "outputs"
+    cmd = [
+        sys.executable,
+        "-m",
+        "scenario_parameter_collection.cli",
+        "--tracks",
+        str(input_dir),
+        "--output-dir",
+        str(output_dir),
+        "--frame-rate",
+        "25.0",
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+    events_path = output_dir / "scenario_events.csv"
+    cli_events = pd.read_csv(events_path)
+    cli_car_following = cli_events[cli_events["scenario"] == "car_following"]
+    assert len(cli_car_following) == 2
+    assert set(cli_car_following["track_id"].astype(int)) == {1}
+    assert set(zip(cli_car_following["start_frame"], cli_car_following["end_frame"])) == {(0, 49)}


### PR DESCRIPTION
## Summary
- group HighD tracks by id plus recording discriminator when available and keep the same keys for lead-vehicle enrichment
- avoid cross-recording merges by including recording metadata in the lead lookup join keys
- add an integration test that builds overlapping synthetic recordings, exercises the detector and CLI, and asserts car-following events stay separated per recording

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca72c474d48326a94fa86f6c59ee9b