### PR TITLE
Refactor scenario detection to tag-combination pipeline

### DIFF
--- a/README
+++ b/README
@@ -11,8 +11,8 @@
 
 ## 功能特性
 
-- 支持识别 12 类高速公路场景：自由巡航、稳定跟车、前车/自车制动、切入/切出、变道、拥堵跟驰、接近静止目标等。
-- 自动补充前车的速度与加速度信息，基于规则的事件检测算法。
+- 支持识别 18 类高速公路场景：自由巡航、自由加速/减速、稳定/紧跟车、接近慢车、前车/自车制动（含紧急制动）、切入/切出、变道、拥堵起步、接近静止目标等。
+- 自动补充前车的速度与加速度信息，并采用“标签组合匹配”的两步场景挖掘方法（先按纵向/横向动作打标签，再顺序匹配标签组合）。
 - 统计每类场景的发生频率以及关键参数的概率密度函数（Gaussian KDE）。
 
 - 支持计算逐步引入 HighD 录制片段时的 MISE、对称 KL 散度、Hellinger 距离，评估何时达到稳定分布。
@@ -45,6 +45,8 @@ python -m scenario_parameter_collection.cli --tracks data/ --output-dir outputs
 - `outputs/erwin_coverage.csv`：Erwin de Gelder 10 大功能场景的覆盖统计（含描述与计数）。
 - `outputs/erwin_coverage_summary.json`：覆盖率汇总（总事件数、已覆盖事件数、覆盖比、未覆盖事件数）。
 - `outputs/unmapped_events.csv`：未能映射到 Erwin 场景的事件明细（场景名称、时间、车道 ID 等）。
+- `outputs/unmatched_frames.csv`：未被任何场景覆盖的帧列表（记录 trackId 与 frame）。
+- `outputs/frame_coverage_summary.json`：帧级覆盖率统计（总帧数、未覆盖帧数、覆盖比例）。
 
 3. **生成可视化报告**：
 
@@ -79,9 +81,10 @@ from scenario_parameter_collection.statistics import estimate_parameter_distribu
 
 tracks = load_tracks("data/01_tracks.csv")
 detector = HighDScenarioDetector(frame_rate=25.0)
-events = detector.detect(tracks)
-stats = estimate_parameter_distributions(events)
+result = detector.detect(tracks)
+stats = estimate_parameter_distributions(result.events)
 
+print(result.coverage_ratio())
 print(stats.counts)
 ```
 

--- a/docs/scenario_catalog.md
+++ b/docs/scenario_catalog.md
@@ -8,26 +8,32 @@
 
 ## 2. 功能场景全景列表
 
-表 1 汇总了高速公路 ADS 设计验证时最常见的 12 类功能场景。选择原则：
+表 1 汇总了高速公路 ADS 设计验证时最常见的 18 类功能场景。选择原则：
 
 1. 在自然驾驶数据中出现频率高，且对纵向或横向安全功能有影响。
 2. 可利用 HighD 的 `precedingId`、车道关系等字段自动识别。
 3. 与行业标准测试工况或学术研究一致。
 
-| 场景编号 | 场景名称 | 典型触发条件 | 关键参数 (示例) |
-| --- | --- | --- | --- |
-| S1 | **自由巡航 (free_driving)** | 无前车 (`precedingId <= 0`) 或前向间距 > 120 m，速度 ≥ 72 km/h | 纵向速度、纵向加速度、持续时间 |
-| S2 | **稳定跟车 (car_following)** | `precedingId` 恒定，时间头距 (THW) 0.8–3 s，速度差 ≤ 3 m/s | 平均 THW、平均距离头距 (DHW)、平均相对速度、持续时间 |
-| S3 | **前车制动 (lead_vehicle_braking)** | 前车纵向减速度 ≤ −2.5 m/s²，THW < 3.5 s | 前车最小减速度、最小 TTC、最小 THW、事件时长 |
-| S4 | **自车制动 (ego_braking)** | 自车纵向减速度 ≤ −3 m/s²，速度在事件内降低 ≥ 1 m/s | 最小自车减速度、速度损失、事件时长 |
-| S5 | **左侧切入 (cut_in_from_left)** | `precedingId` 从无/他车切换为新 ID，并与左邻车 ID 匹配 | 切入后间距、切入后相对速度、切入后 TTC |
-| S6 | **右侧切入 (cut_in_from_right)** | `precedingId` 切换，并与右邻车 ID 匹配 | 切入后间距、切入后相对速度、切入后 TTC |
-| S7 | **左侧切出 (cut_out_to_left)** | 现有前车 ID 消失，同时在左侧邻车列表出现 | 切出前间距、切出前相对速度 |
-| S8 | **右侧切出 (cut_out_to_right)** | 现有前车 ID 消失，同时在右侧邻车列表出现 | 切出前间距、切出前相对速度 |
-| S9 | **自车左变道 (ego_lane_change_left)** | `laneId` 减少且维持，存在非零横向速度 | 变道持续时间、最大横向速度、平均纵向速度 |
-| S10 | **自车右变道 (ego_lane_change_right)** | `laneId` 增加且维持，存在非零横向速度 | 变道持续时间、最大横向速度、平均纵向速度 |
-| S11 | **拥堵跟驰 (slow_traffic)** | 前车存在，速度 ≤ 30 km/h，THW ≤ 2 s | 平均速度、平均 THW、持续时间 |
-| S12 | **接近静止目标 (stationary_lead)** | 前车速度 ≤ 2 m/s，TTC ≤ 4 s | 最小 TTC、前车平均速度、持续时间 |
+| 场景编号 | 场景名称 | 典型触发条件 | 标签组合 (必需/可选/排除) | 关键参数 (示例) |
+| --- | --- | --- | --- | --- |
+| S1 | **自由巡航 (free_driving)** | 无前车 (`precedingId <= 0`) 或前向间距 > 120 m，速度 ≥ 72 km/h | 必需：`tag_lane_keep`、`tag_free_flow`、`tag_speed_high`；可选：`tag_lon_cruising` 或 `tag_lon_accelerating` | 纵向速度、纵向加速度、持续时间 |
+| S2 | **自由加速 (free_acceleration)** | 无前车或距离充足，纵向加速为正 | 必需：`tag_free_flow`、`tag_lon_accelerating`；排除：`tag_lead_present` | 纵向速度、纵向加速度、持续时间 |
+| S3 | **自由减速 (free_deceleration)** | 无前车或距离充足，自车主动减速 | 必需：`tag_free_flow`、`tag_lon_decelerating`；排除：`tag_lead_present` | 纵向速度、纵向加速度、持续时间 |
+| S4 | **稳定跟车 (car_following)** | `precedingId` 恒定，时间头距 (THW) 0.8–3 s，速度差 ≤ 3 m/s | 必需：`tag_lead_present`、`tag_following_medium`、`tag_lane_keep`；排除：`tag_following_close` | 平均 THW、平均距离头距 (DHW)、平均相对速度、持续时间 |
+| S5 | **紧跟车 (car_following_close)** | THW < 1 s，仍保持同车道跟驰 | 必需：`tag_lead_present`、`tag_following_close`、`tag_lane_keep` | 平均 THW、最小 THW、平均相对速度、持续时间 |
+| S6 | **接近慢车 (approaching_lead_vehicle)** | 相对速度为正，持续缩短车距 | 必需：`tag_lead_present`、`tag_approaching_lead`、`tag_lane_keep`；排除：`tag_lead_braking` | 平均相对速度、最小 TTC、最小 THW、持续时间 |
+| S7 | **前车制动 (lead_vehicle_braking)** | 前车纵向减速度 ≤ −2.5 m/s²，THW < 3.5 s | 必需：`tag_lead_present`、`tag_lead_braking` | 前车最小减速度、最小 TTC、最小 THW、事件时长 |
+| S8 | **自车制动 (ego_braking)** | 自车纵向减速度 ≤ −3 m/s²，速度下降 ≥ 1 m/s | 必需：`tag_lon_decelerating`；排除：`tag_lead_braking` | 最小自车减速度、速度损失、事件时长 |
+| S9 | **紧急制动 (ego_emergency_braking)** | 自车减速度低于 −3 m/s²，出现明显冲击 | 必需：`tag_lon_hard_brake` | 最小减速度、速度损失、最大冲击、持续时间 |
+| S10 | **左侧切入 (cut_in_from_left)** | `precedingId` 切换为左邻车 ID | 必需：`tag_cut_in_left` | 切入后间距、切入后相对速度、切入后 TTC |
+| S11 | **右侧切入 (cut_in_from_right)** | `precedingId` 切换为右邻车 ID | 必需：`tag_cut_in_right` | 切入后间距、切入后相对速度、切入后 TTC |
+| S12 | **左侧切出 (cut_out_to_left)** | 现有前车转入左车道 | 必需：`tag_cut_out_left` | 切出前间距、切出前相对速度、观察窗口时长 |
+| S13 | **右侧切出 (cut_out_to_right)** | 现有前车转入右车道 | 必需：`tag_cut_out_right` | 切出前间距、切出前相对速度、观察窗口时长 |
+| S14 | **自车左变道 (ego_lane_change_left)** | `laneId` 减少且维持，存在横向速度 | 必需：`tag_lane_change_left` | 变道持续时间、最大横向速度、平均纵向速度 |
+| S15 | **自车右变道 (ego_lane_change_right)** | `laneId` 增加且维持，存在横向速度 | 必需：`tag_lane_change_right` | 变道持续时间、最大横向速度、平均纵向速度 |
+| S16 | **拥堵跟驰 (slow_traffic)** | 前车存在，速度 ≤ 30 km/h，THW ≤ 2 s | 必需：`tag_lead_present`、`tag_slow_speed` | 平均速度、平均 THW、持续时间 |
+| S17 | **拥堵起步 (stop_and_go_start)** | 拥堵工况下由静止开始加速 | 必需：`tag_lead_present`、`tag_stop_and_go` | 最大加速度、结束速度、持续时间 |
+| S18 | **接近静止目标 (stationary_lead)** | 前车速度 ≤ 2 m/s，TTC ≤ 4 s | 必需：`tag_lead_present`、`tag_lead_stationary` | 最小 TTC、前车平均速度、持续时间 |
 
 附加说明：
 - HighD 车道编号遵循德国高速公路惯例：数值越小车道越靠左。自车左变道表现为 `laneId` 减少。
@@ -50,9 +56,10 @@
 ## 4. 自动识别方法概述
 
 1. **数据预处理**：按 `id`、`frame` 排序，补充前车 (`precedingId`) 的速度、加速度，统一缺测值。
-2. **事件检测**：基于规则的判别器（见 `scenario_parameter_collection/detection.py`），为每辆车独立识别各类场景。
-3. **参数抽取**：在事件窗口内计算平均值、最小值、速度损失等关键参数。
-4. **统计分析**：对所有事件做频率统计，并对每个场景的关键参数执行 KDE 估计，得到概率密度函数。
+2. **标签生成**：依照《Real-World Scenario Mining for the Assessment of Automated Vehicles》提出的“两步走”策略，先对每一帧计算纵向（加速/减速/巡航、接近慢车、前车制动等）和横向（保持车道、变道、切入/切出）标签。
+3. **标签组合匹配**：将表 1 中的场景类别映射为“必需标签 / 可选标签 / 排除标签”的组合，在时间轴上顺序匹配得到连续片段。
+4. **参数抽取**：在事件窗口内计算平均值、最小值、速度损失等关键参数。
+5. **统计分析**：对所有事件做频率统计，并对每个场景的关键参数执行 KDE 估计，得到概率密度函数。
 
 ## 5. 应用场景
 

--- a/src/scenario_parameter_collection/__init__.py
+++ b/src/scenario_parameter_collection/__init__.py
@@ -16,7 +16,7 @@ from .convergence import (
     ScenarioConvergenceAnalyzer,
 )
 
-from .detection import HighDScenarioDetector, ScenarioEvent
+from .detection import DetectionResult, HighDScenarioDetector, ScenarioEvent
 from .statistics import ScenarioStatistics, estimate_parameter_distributions
 
 __all__ = [
@@ -26,6 +26,7 @@ __all__ = [
     "ERWIN_SCENARIOS",
     "SCENARIO_TO_ERWIN",
     "HighDScenarioDetector",
+    "DetectionResult",
     "ScenarioEvent",
     "ErwinCoverageSummary",
     "UnmatchedEvent",

--- a/src/scenario_parameter_collection/catalog.py
+++ b/src/scenario_parameter_collection/catalog.py
@@ -25,40 +25,52 @@ class ScenarioDefinition:
     triggers: List[str]
     key_parameters: List[ScenarioParameter]
     references: List[str] = field(default_factory=list)
+    tag_combination: Dict[str, List[str]] = field(default_factory=dict)
 
 
 SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
-    "free_driving": ScenarioDefinition(
-        name="free_driving",
-        description="Ego vehicle cruises without a relevant preceding vehicle within the sensor range.",
+    "approaching_lead_vehicle": ScenarioDefinition(
+        name="approaching_lead_vehicle",
+        description="Ego vehicle closes the gap to a slower lead while remaining in lane.",
         triggers=[
-            "No precedingId reported or distance headway beyond perception range",
-            "Longitudinal speed above the minimum cruise threshold",
+            "Positive relative speed towards the lead vehicle",
+            "Stable lane keeping",
+            "Moderate headway values",
         ],
         key_parameters=[
             ScenarioParameter(
-                name="speed",
-                description="Ego longitudinal speed",
+                name="mean_relative_speed",
+                description="Average closing speed",
                 unit="m/s",
-                typical_range=(20.0, 45.0),
+                typical_range=(0.5, 8.0),
             ),
             ScenarioParameter(
-                name="acceleration",
-                description="Ego longitudinal acceleration",
-                unit="m/s^2",
-                typical_range=(-1.5, 1.5),
+                name="min_ttc",
+                description="Minimum time-to-collision",
+                unit="s",
+                typical_range=(0.5, 6.0),
+            ),
+            ScenarioParameter(
+                name="min_thw",
+                description="Minimum time headway",
+                unit="s",
+                typical_range=(0.5, 2.5),
             ),
             ScenarioParameter(
                 name="duration_s",
-                description="Length of the free-driving episode",
+                description="Event duration",
                 unit="s",
-                typical_range=(2.0, 60.0),
+                typical_range=(1.0, 20.0),
             ),
         ],
         references=[
-            "ISO 34502 Annex A free driving",
-            "HighD benchmark studies on free-flow traffic",
+            "ISO 34502 approaching slower vehicle",
+            "HighD closing speed analyses",
         ],
+        tag_combination={
+            "required": ["tag_lead_present", "tag_approaching_lead", "tag_lane_keep"],
+            "forbidden": ["tag_lead_braking"],
+        },
     ),
     "car_following": ScenarioDefinition(
         name="car_following",
@@ -97,6 +109,443 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "Treiber et al. Intelligent Driver Model calibration",
             "HighD lane-wise following studies",
         ],
+        tag_combination={
+            "required": ["tag_lead_present", "tag_following_medium", "tag_lane_keep"],
+            "forbidden": ["tag_following_close"],
+        },
+    ),
+    "car_following_close": ScenarioDefinition(
+        name="car_following_close",
+        description="Tight following with small headway that approaches comfort limits.",
+        triggers=[
+            "Time headway below 1.0 s",
+            "Lead vehicle present on same lane",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="mean_thw",
+                description="Average time headway",
+                unit="s",
+                typical_range=(0.4, 1.0),
+            ),
+            ScenarioParameter(
+                name="mean_dhw",
+                description="Average distance headway",
+                unit="m",
+                typical_range=(5.0, 25.0),
+            ),
+            ScenarioParameter(
+                name="mean_relative_speed",
+                description="Average relative speed",
+                unit="m/s",
+                typical_range=(-3.0, 3.0),
+            ),
+            ScenarioParameter(
+                name="min_thw",
+                description="Minimum time headway",
+                unit="s",
+                typical_range=(0.3, 0.8),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Event duration",
+                unit="s",
+                typical_range=(1.0, 30.0),
+            ),
+        ],
+        references=[
+            "ISO 34502 close-following scenario",
+            "Adaptive cruise control validation studies",
+        ],
+        tag_combination={
+            "required": ["tag_lead_present", "tag_following_close", "tag_lane_keep"],
+        },
+    ),
+    "cut_in_from_left": ScenarioDefinition(
+        name="cut_in_from_left",
+        description="A vehicle from the left adjacent lane merges in front of ego and becomes the new leader.",
+        triggers=[
+            "PrecedingId switch accompanied by left-neighbour identifiers",
+            "Sharp decrease of distance headway",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="gap_post_cut",
+                description="Distance headway immediately after the cut-in",
+                unit="m",
+                typical_range=(5.0, 40.0),
+            ),
+            ScenarioParameter(
+                name="relative_speed_post",
+                description="Relative speed to the cutting-in vehicle",
+                unit="m/s",
+                typical_range=(-5.0, 5.0),
+            ),
+            ScenarioParameter(
+                name="ttc_post",
+                description="Time-to-collision after the cut-in",
+                unit="s",
+                typical_range=(0.5, 6.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Observation window around the cut-in",
+                unit="s",
+                typical_range=(0.5, 4.0),
+            ),
+        ],
+        references=[
+            "NHTSA lane change scenario definitions",
+            "Real-world scenario mining tag combinations",
+        ],
+        tag_combination={"required": ["tag_cut_in_left"]},
+    ),
+    "cut_in_from_right": ScenarioDefinition(
+        name="cut_in_from_right",
+        description="A vehicle from the right adjacent lane merges in front of ego and becomes the new leader.",
+        triggers=[
+            "PrecedingId switch accompanied by right-neighbour identifiers",
+            "Gap reduction in right-to-left manoeuvre",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="gap_post_cut",
+                description="Distance headway immediately after the cut-in",
+                unit="m",
+                typical_range=(5.0, 40.0),
+            ),
+            ScenarioParameter(
+                name="relative_speed_post",
+                description="Relative speed to the cutting-in vehicle",
+                unit="m/s",
+                typical_range=(-5.0, 5.0),
+            ),
+            ScenarioParameter(
+                name="ttc_post",
+                description="Time-to-collision after the cut-in",
+                unit="s",
+                typical_range=(0.5, 6.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Observation window around the cut-in",
+                unit="s",
+                typical_range=(0.5, 4.0),
+            ),
+        ],
+        references=[
+            "NHTSA lane change scenario definitions",
+            "Real-world scenario mining tag combinations",
+        ],
+        tag_combination={"required": ["tag_cut_in_right"]},
+    ),
+    "cut_out_to_left": ScenarioDefinition(
+        name="cut_out_to_left",
+        description="The current lead vehicle leaves the lane to the left, exposing a new lead vehicle or free space.",
+        triggers=[
+            "PrecedingId disappears and appears among left-lane neighbours",
+            "Increase in distance headway or TTC",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="gap_before_cut",
+                description="Distance headway shortly before the cut-out",
+                unit="m",
+                typical_range=(5.0, 60.0),
+            ),
+            ScenarioParameter(
+                name="relative_speed_before",
+                description="Relative speed prior to the cut-out",
+                unit="m/s",
+                typical_range=(-5.0, 5.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Observation window around the cut-out",
+                unit="s",
+                typical_range=(0.5, 4.0),
+            ),
+        ],
+        references=[
+            "ISO 34502 cut-out scenario taxonomy",
+        ],
+        tag_combination={"required": ["tag_cut_out_left"]},
+    ),
+    "cut_out_to_right": ScenarioDefinition(
+        name="cut_out_to_right",
+        description="The current lead vehicle leaves the lane to the right, exposing a new lead vehicle or free space.",
+        triggers=[
+            "PrecedingId disappears and appears among right-lane neighbours",
+            "Increase in distance headway or TTC",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="gap_before_cut",
+                description="Distance headway shortly before the cut-out",
+                unit="m",
+                typical_range=(5.0, 60.0),
+            ),
+            ScenarioParameter(
+                name="relative_speed_before",
+                description="Relative speed prior to the cut-out",
+                unit="m/s",
+                typical_range=(-5.0, 5.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Observation window around the cut-out",
+                unit="s",
+                typical_range=(0.5, 4.0),
+            ),
+        ],
+        references=[
+            "ISO 34502 cut-out scenario taxonomy",
+        ],
+        tag_combination={"required": ["tag_cut_out_right"]},
+    ),
+    "ego_braking": ScenarioDefinition(
+        name="ego_braking",
+        description="Ego vehicle executes strong longitudinal deceleration irrespective of lead vehicle behaviour.",
+        triggers=[
+            "Ego longitudinal acceleration below braking threshold",
+            "Speed reduction above minimum delta",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="min_acc",
+                description="Minimum ego longitudinal acceleration",
+                unit="m/s^2",
+                typical_range=(-6.0, -2.0),
+            ),
+            ScenarioParameter(
+                name="speed_drop",
+                description="Speed reduction achieved during the event",
+                unit="m/s",
+                typical_range=(2.0, 20.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Event duration",
+                unit="s",
+                typical_range=(0.5, 5.0),
+            ),
+        ],
+        references=[
+            "UNECE emergency braking test descriptions",
+        ],
+        tag_combination={
+            "required": ["tag_lon_decelerating"],
+            "forbidden": ["tag_lead_braking"],
+        },
+    ),
+    "ego_emergency_braking": ScenarioDefinition(
+        name="ego_emergency_braking",
+        description="Ego vehicle performs a severe braking manoeuvre exceeding emergency thresholds.",
+        triggers=[
+            "Longitudinal deceleration below -3 m/s²",
+            "Potential ABS/ESP activation",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="min_acc",
+                description="Minimum ego longitudinal acceleration",
+                unit="m/s^2",
+                typical_range=(-10.0, -3.0),
+            ),
+            ScenarioParameter(
+                name="speed_drop",
+                description="Speed reduction achieved during the event",
+                unit="m/s",
+                typical_range=(5.0, 25.0),
+            ),
+            ScenarioParameter(
+                name="peak_jerk",
+                description="Maximum jerk observed during the event",
+                unit="m/s^3",
+                typical_range=(5.0, 30.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Event duration",
+                unit="s",
+                typical_range=(0.3, 3.0),
+            ),
+        ],
+        references=[
+            "UNECE Automated Lane Keeping emergency braking",
+        ],
+        tag_combination={"required": ["tag_lon_hard_brake"]},
+    ),
+    "ego_lane_change_left": ScenarioDefinition(
+        name="ego_lane_change_left",
+        description="Ego vehicle changes to a lane with a lower numerical identifier (assumed to be left).",
+        triggers=[
+            "LaneId decrease sustained for more than one frame",
+            "Non-zero lateral velocity during the transition",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="duration_s",
+                description="Transition duration",
+                unit="s",
+                typical_range=(1.0, 6.0),
+            ),
+            ScenarioParameter(
+                name="max_abs_y_velocity",
+                description="Maximum absolute lateral speed during the manoeuvre",
+                unit="m/s",
+                typical_range=(0.1, 3.0),
+            ),
+            ScenarioParameter(
+                name="speed_mean",
+                description="Mean longitudinal speed during the manoeuvre",
+                unit="m/s",
+                typical_range=(15.0, 40.0),
+            ),
+        ],
+        references=[
+            "HighD lane-change benchmark",
+        ],
+        tag_combination={"required": ["tag_lane_change_left"]},
+    ),
+    "ego_lane_change_right": ScenarioDefinition(
+        name="ego_lane_change_right",
+        description="Ego vehicle changes to a lane with a higher numerical identifier (assumed to be right).",
+        triggers=[
+            "LaneId increase sustained for more than one frame",
+            "Non-zero lateral velocity during the transition",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="duration_s",
+                description="Transition duration",
+                unit="s",
+                typical_range=(1.0, 6.0),
+            ),
+            ScenarioParameter(
+                name="max_abs_y_velocity",
+                description="Maximum absolute lateral speed during the manoeuvre",
+                unit="m/s",
+                typical_range=(0.1, 3.0),
+            ),
+            ScenarioParameter(
+                name="speed_mean",
+                description="Mean longitudinal speed during the manoeuvre",
+                unit="m/s",
+                typical_range=(15.0, 40.0),
+            ),
+        ],
+        references=[
+            "HighD lane-change benchmark",
+        ],
+        tag_combination={"required": ["tag_lane_change_right"]},
+    ),
+    "free_acceleration": ScenarioDefinition(
+        name="free_acceleration",
+        description="Ego accelerates on a free lane without relevant lead vehicles.",
+        triggers=[
+            "No preceding vehicle or large gap",
+            "Positive longitudinal acceleration",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="speed",
+                description="Mean speed during the episode",
+                unit="m/s",
+                typical_range=(10.0, 45.0),
+            ),
+            ScenarioParameter(
+                name="acceleration",
+                description="Mean longitudinal acceleration",
+                unit="m/s^2",
+                typical_range=(0.3, 2.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Episode duration",
+                unit="s",
+                typical_range=(1.0, 20.0),
+            ),
+        ],
+        references=[
+            "ISO 34502 free-driving acceleration",
+            "Scenario mining tag dictionaries",
+        ],
+        tag_combination={
+            "required": ["tag_free_flow", "tag_lon_accelerating"],
+            "forbidden": ["tag_lead_present"],
+        },
+    ),
+    "free_deceleration": ScenarioDefinition(
+        name="free_deceleration",
+        description="Ego reduces speed on a free lane without active lead vehicles.",
+        triggers=[
+            "No relevant preceding vehicle",
+            "Negative longitudinal acceleration",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="speed",
+                description="Mean speed during the episode",
+                unit="m/s",
+                typical_range=(10.0, 45.0),
+            ),
+            ScenarioParameter(
+                name="acceleration",
+                description="Mean longitudinal acceleration",
+                unit="m/s^2",
+                typical_range=(-2.0, -0.3),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Episode duration",
+                unit="s",
+                typical_range=(1.0, 20.0),
+            ),
+        ],
+        references=[
+            "Motorway comfort braking analyses",
+        ],
+        tag_combination={
+            "required": ["tag_free_flow", "tag_lon_decelerating"],
+            "forbidden": ["tag_lead_present"],
+        },
+    ),
+    "free_driving": ScenarioDefinition(
+        name="free_driving",
+        description="Ego vehicle cruises without a relevant preceding vehicle within the sensor range.",
+        triggers=[
+            "No precedingId reported or distance headway beyond perception range",
+            "Longitudinal speed above the minimum cruise threshold",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="speed",
+                description="Ego longitudinal speed",
+                unit="m/s",
+                typical_range=(20.0, 45.0),
+            ),
+            ScenarioParameter(
+                name="acceleration",
+                description="Ego longitudinal acceleration",
+                unit="m/s^2",
+                typical_range=(-1.5, 1.5),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Length of the free-driving episode",
+                unit="s",
+                typical_range=(2.0, 60.0),
+            ),
+        ],
+        references=[
+            "ISO 34502 Annex A free driving",
+            "HighD benchmark studies on free-flow traffic",
+        ],
+        tag_combination={
+            "required": ["tag_lane_keep", "tag_free_flow", "tag_speed_high"],
+            "any": ["tag_lon_cruising", "tag_lon_accelerating"],
+        },
     ),
     "lead_vehicle_braking": ScenarioDefinition(
         name="lead_vehicle_braking",
@@ -135,211 +584,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "EuroNCAP AEB car-to-car rear stationary/moving scenarios",
             "SOTIF examples for lead vehicle braking",
         ],
-    ),
-    "ego_braking": ScenarioDefinition(
-        name="ego_braking",
-        description="Ego vehicle executes strong longitudinal deceleration irrespective of lead vehicle behaviour.",
-        triggers=[
-            "Ego longitudinal acceleration below braking threshold",
-            "Speed reduction above minimum delta",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="min_acc",
-                description="Minimum ego longitudinal acceleration",
-                unit="m/s^2",
-                typical_range=(-6.0, -2.0),
-            ),
-            ScenarioParameter(
-                name="speed_drop",
-                description="Speed reduction achieved during the event",
-                unit="m/s",
-                typical_range=(2.0, 20.0),
-            ),
-            ScenarioParameter(
-                name="duration_s",
-                description="Event duration",
-                unit="s",
-                typical_range=(0.5, 5.0),
-            ),
-        ],
-        references=[
-            "UNECE emergency braking test descriptions",
-        ],
-    ),
-    "cut_in_from_left": ScenarioDefinition(
-        name="cut_in_from_left",
-        description="A vehicle from the left adjacent lane merges in front of ego and becomes the new leader.",
-        triggers=[
-            "PrecedingId switch accompanied by left-neighbour identifiers",
-            "Sharp decrease of distance headway",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="gap_post_cut",
-                description="Distance headway immediately after the cut-in",
-                unit="m",
-                typical_range=(5.0, 40.0),
-            ),
-            ScenarioParameter(
-                name="relative_speed_post",
-                description="Relative speed to the cutting-in vehicle",
-                unit="m/s",
-                typical_range=(-5.0, 5.0),
-            ),
-            ScenarioParameter(
-                name="ttc_post",
-                description="Time-to-collision after the cut-in",
-                unit="s",
-                typical_range=(0.5, 6.0),
-            ),
-        ],
-        references=[
-            "NHTSA lane change scenario definitions",
-        ],
-    ),
-    "cut_in_from_right": ScenarioDefinition(
-        name="cut_in_from_right",
-        description="A vehicle from the right adjacent lane merges in front of ego and becomes the new leader.",
-        triggers=[
-            "PrecedingId switch accompanied by right-neighbour identifiers",
-            "Gap reduction in right-to-left manoeuvre",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="gap_post_cut",
-                description="Distance headway immediately after the cut-in",
-                unit="m",
-                typical_range=(5.0, 40.0),
-            ),
-            ScenarioParameter(
-                name="relative_speed_post",
-                description="Relative speed to the cutting-in vehicle",
-                unit="m/s",
-                typical_range=(-5.0, 5.0),
-            ),
-            ScenarioParameter(
-                name="ttc_post",
-                description="Time-to-collision after the cut-in",
-                unit="s",
-                typical_range=(0.5, 6.0),
-            ),
-        ],
-        references=[
-            "NHTSA lane change scenario definitions",
-        ],
-    ),
-    "cut_out_to_left": ScenarioDefinition(
-        name="cut_out_to_left",
-        description="The current lead vehicle leaves the lane to the left, exposing a new lead vehicle or free space.",
-        triggers=[
-            "PrecedingId disappears and appears among left-lane neighbours",
-            "Increase in distance headway or TTC",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="gap_before_cut",
-                description="Distance headway shortly before the cut-out",
-                unit="m",
-                typical_range=(5.0, 60.0),
-            ),
-            ScenarioParameter(
-                name="relative_speed_before",
-                description="Relative speed prior to the cut-out",
-                unit="m/s",
-                typical_range=(-5.0, 5.0),
-            ),
-        ],
-        references=[
-            "ISO 34502 cut-out scenario taxonomy",
-        ],
-    ),
-    "cut_out_to_right": ScenarioDefinition(
-        name="cut_out_to_right",
-        description="The current lead vehicle leaves the lane to the right, exposing a new lead vehicle or free space.",
-        triggers=[
-            "PrecedingId disappears and appears among right-lane neighbours",
-            "Increase in distance headway or TTC",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="gap_before_cut",
-                description="Distance headway shortly before the cut-out",
-                unit="m",
-                typical_range=(5.0, 60.0),
-            ),
-            ScenarioParameter(
-                name="relative_speed_before",
-                description="Relative speed prior to the cut-out",
-                unit="m/s",
-                typical_range=(-5.0, 5.0),
-            ),
-        ],
-        references=[
-            "ISO 34502 cut-out scenario taxonomy",
-        ],
-    ),
-    "ego_lane_change_left": ScenarioDefinition(
-        name="ego_lane_change_left",
-        description="Ego vehicle changes to a lane with a lower numerical identifier (assumed to be left).",
-        triggers=[
-            "LaneId decrease sustained for more than one frame",
-            "Non-zero lateral velocity during the transition",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="duration_s",
-                description="Transition duration",
-                unit="s",
-                typical_range=(1.0, 6.0),
-            ),
-            ScenarioParameter(
-                name="max_abs_y_velocity",
-                description="Maximum absolute lateral speed during the manoeuvre",
-                unit="m/s",
-                typical_range=(0.1, 3.0),
-            ),
-            ScenarioParameter(
-                name="speed_mean",
-                description="Mean longitudinal speed during the manoeuvre",
-                unit="m/s",
-                typical_range=(15.0, 40.0),
-            ),
-        ],
-        references=[
-            "HighD lane-change benchmark",
-        ],
-    ),
-    "ego_lane_change_right": ScenarioDefinition(
-        name="ego_lane_change_right",
-        description="Ego vehicle changes to a lane with a higher numerical identifier (assumed to be right).",
-        triggers=[
-            "LaneId increase sustained for more than one frame",
-            "Non-zero lateral velocity during the transition",
-        ],
-        key_parameters=[
-            ScenarioParameter(
-                name="duration_s",
-                description="Transition duration",
-                unit="s",
-                typical_range=(1.0, 6.0),
-            ),
-            ScenarioParameter(
-                name="max_abs_y_velocity",
-                description="Maximum absolute lateral speed during the manoeuvre",
-                unit="m/s",
-                typical_range=(0.1, 3.0),
-            ),
-            ScenarioParameter(
-                name="speed_mean",
-                description="Mean longitudinal speed during the manoeuvre",
-                unit="m/s",
-                typical_range=(15.0, 40.0),
-            ),
-        ],
-        references=[
-            "HighD lane-change benchmark",
-        ],
+        tag_combination={"required": ["tag_lead_present", "tag_lead_braking"]},
     ),
     "slow_traffic": ScenarioDefinition(
         name="slow_traffic",
@@ -371,6 +616,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
         references=[
             "Stop-and-go traffic characterisation in NGSim/HighD",
         ],
+        tag_combination={"required": ["tag_lead_present", "tag_slow_speed"]},
     ),
     "stationary_lead": ScenarioDefinition(
         name="stationary_lead",
@@ -402,6 +648,39 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
         references=[
             "AEB stationary target scenarios",
         ],
+        tag_combination={"required": ["tag_lead_present", "tag_lead_stationary"]},
+    ),
+    "stop_and_go_start": ScenarioDefinition(
+        name="stop_and_go_start",
+        description="Ego accelerates from low speed in congestion following a lead vehicle.",
+        triggers=[
+            "Low ego speed followed by acceleration",
+            "Lead vehicle present",
+        ],
+        key_parameters=[
+            ScenarioParameter(
+                name="max_acc",
+                description="Maximum longitudinal acceleration during the start",
+                unit="m/s^2",
+                typical_range=(0.5, 3.0),
+            ),
+            ScenarioParameter(
+                name="final_speed",
+                description="Speed at the end of the analysed window",
+                unit="m/s",
+                typical_range=(5.0, 20.0),
+            ),
+            ScenarioParameter(
+                name="duration_s",
+                description="Duration of the acceleration phase",
+                unit="s",
+                typical_range=(1.0, 10.0),
+            ),
+        ],
+        references=[
+            "Stop-and-go comfort studies",
+        ],
+        tag_combination={"required": ["tag_lead_present", "tag_stop_and_go"]},
     ),
 }
 

--- a/src/scenario_parameter_collection/convergence.py
+++ b/src/scenario_parameter_collection/convergence.py
@@ -260,7 +260,8 @@ class ScenarioConvergenceAnalyzer:
             aggregated_tracks.append(new_tracks)
             merged_tracks = pd.concat(aggregated_tracks, ignore_index=True, sort=False)
 
-            events = detector.detect(merged_tracks)
+            detection_result = detector.detect(merged_tracks)
+            events = detection_result.events
             stats = estimate_parameter_distributions(
                 events,
                 scenario_definitions=self.scenario_definitions,

--- a/src/scenario_parameter_collection/coverage.py
+++ b/src/scenario_parameter_collection/coverage.py
@@ -104,15 +104,18 @@ ERWIN_SCENARIOS: Dict[str, ErwinScenario] = {
 
 SCENARIO_TO_ERWIN: Dict[str, str] = {
     "car_following": "follow_vehicle_cruise",
+    "car_following_close": "follow_vehicle_cruise",
     "slow_traffic": "approach_low_speed_vehicle",
     "stationary_lead": "approach_low_speed_vehicle",
     "lead_vehicle_braking": "lead_vehicle_braking",
+    "approaching_lead_vehicle": "approach_low_speed_vehicle",
     "cut_in_from_left": "lead_vehicle_cut_in",
     "cut_in_from_right": "lead_vehicle_cut_in",
     "cut_out_to_left": "lead_vehicle_cut_out",
     "cut_out_to_right": "lead_vehicle_cut_out",
     "ego_lane_change_left": "ego_lane_change_with_trailing_vehicle",
     "ego_lane_change_right": "ego_lane_change_with_trailing_vehicle",
+    "ego_emergency_braking": "lead_vehicle_braking",
 }
 
 


### PR DESCRIPTION
## Summary
- replace the rule-per-scenario heuristics with a tag-based detection engine that emits coverage metadata and supports an expanded highway scenario catalogue
- extend the CLI outputs to include unmatched frame listings and coverage summaries while surfacing frame coverage in the console
- refresh documentation and tests to describe the 18-scenario library, tag combinations, and new detection result API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d90f2a90b88326a059142febfea10b