### PR TITLE
Refactor HighD scenario patterns to reuse catalog tag combos

### DIFF
--- a/src/scenario_parameter_collection/catalog.py
+++ b/src/scenario_parameter_collection/catalog.py
@@ -26,6 +26,8 @@ class ScenarioDefinition:
     key_parameters: List[ScenarioParameter]
     references: List[str] = field(default_factory=list)
     tag_combination: Dict[str, List[str]] = field(default_factory=dict)
+    min_duration_s: float = 1.0
+    expansion_s: float = 0.0
 
 
 SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
@@ -71,6 +73,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "required": ["tag_lead_present", "tag_approaching_lead", "tag_lane_keep"],
             "forbidden": ["tag_lead_braking"],
         },
+        min_duration_s=1.2,
     ),
     "car_following": ScenarioDefinition(
         name="car_following",
@@ -113,6 +116,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "required": ["tag_lead_present", "tag_following_medium", "tag_lane_keep"],
             "forbidden": ["tag_following_close"],
         },
+        min_duration_s=1.5,
     ),
     "car_following_close": ScenarioDefinition(
         name="car_following_close",
@@ -160,6 +164,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
         tag_combination={
             "required": ["tag_lead_present", "tag_following_close", "tag_lane_keep"],
         },
+        min_duration_s=1.6,
     ),
     "cut_in_from_left": ScenarioDefinition(
         name="cut_in_from_left",
@@ -199,6 +204,8 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "Real-world scenario mining tag combinations",
         ],
         tag_combination={"required": ["tag_cut_in_left"]},
+        min_duration_s=0.4,
+        expansion_s=0.4,
     ),
     "cut_in_from_right": ScenarioDefinition(
         name="cut_in_from_right",
@@ -238,6 +245,8 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "Real-world scenario mining tag combinations",
         ],
         tag_combination={"required": ["tag_cut_in_right"]},
+        min_duration_s=0.4,
+        expansion_s=0.4,
     ),
     "cut_out_to_left": ScenarioDefinition(
         name="cut_out_to_left",
@@ -270,6 +279,8 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "ISO 34502 cut-out scenario taxonomy",
         ],
         tag_combination={"required": ["tag_cut_out_left"]},
+        min_duration_s=0.4,
+        expansion_s=0.4,
     ),
     "cut_out_to_right": ScenarioDefinition(
         name="cut_out_to_right",
@@ -302,6 +313,8 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "ISO 34502 cut-out scenario taxonomy",
         ],
         tag_combination={"required": ["tag_cut_out_right"]},
+        min_duration_s=0.4,
+        expansion_s=0.4,
     ),
     "ego_braking": ScenarioDefinition(
         name="ego_braking",
@@ -337,6 +350,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "required": ["tag_lon_decelerating"],
             "forbidden": ["tag_lead_braking"],
         },
+        min_duration_s=0.8,
     ),
     "ego_emergency_braking": ScenarioDefinition(
         name="ego_emergency_braking",
@@ -375,6 +389,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "UNECE Automated Lane Keeping emergency braking",
         ],
         tag_combination={"required": ["tag_lon_hard_brake"]},
+        min_duration_s=0.4,
     ),
     "ego_lane_change_left": ScenarioDefinition(
         name="ego_lane_change_left",
@@ -407,6 +422,8 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "HighD lane-change benchmark",
         ],
         tag_combination={"required": ["tag_lane_change_left"]},
+        min_duration_s=1.0,
+        expansion_s=0.4,
     ),
     "ego_lane_change_right": ScenarioDefinition(
         name="ego_lane_change_right",
@@ -439,6 +456,8 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "HighD lane-change benchmark",
         ],
         tag_combination={"required": ["tag_lane_change_right"]},
+        min_duration_s=1.0,
+        expansion_s=0.4,
     ),
     "free_acceleration": ScenarioDefinition(
         name="free_acceleration",
@@ -475,6 +494,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "required": ["tag_free_flow", "tag_lon_accelerating"],
             "forbidden": ["tag_lead_present"],
         },
+        min_duration_s=1.2,
     ),
     "free_deceleration": ScenarioDefinition(
         name="free_deceleration",
@@ -510,6 +530,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "required": ["tag_free_flow", "tag_lon_decelerating"],
             "forbidden": ["tag_lead_present"],
         },
+        min_duration_s=1.2,
     ),
     "free_driving": ScenarioDefinition(
         name="free_driving",
@@ -546,6 +567,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "required": ["tag_lane_keep", "tag_free_flow", "tag_speed_high"],
             "any": ["tag_lon_cruising", "tag_lon_accelerating"],
         },
+        min_duration_s=2.0,
     ),
     "lead_vehicle_braking": ScenarioDefinition(
         name="lead_vehicle_braking",
@@ -585,6 +607,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "SOTIF examples for lead vehicle braking",
         ],
         tag_combination={"required": ["tag_lead_present", "tag_lead_braking"]},
+        min_duration_s=0.6,
     ),
     "slow_traffic": ScenarioDefinition(
         name="slow_traffic",
@@ -617,6 +640,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "Stop-and-go traffic characterisation in NGSim/HighD",
         ],
         tag_combination={"required": ["tag_lead_present", "tag_slow_speed"]},
+        min_duration_s=3.0,
     ),
     "stationary_lead": ScenarioDefinition(
         name="stationary_lead",
@@ -649,6 +673,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "AEB stationary target scenarios",
         ],
         tag_combination={"required": ["tag_lead_present", "tag_lead_stationary"]},
+        min_duration_s=0.6,
     ),
     "stop_and_go_start": ScenarioDefinition(
         name="stop_and_go_start",
@@ -681,6 +706,7 @@ SCENARIO_DEFINITIONS: Dict[str, ScenarioDefinition] = {
             "Stop-and-go comfort studies",
         ],
         tag_combination={"required": ["tag_lead_present", "tag_stop_and_go"]},
+        min_duration_s=1.0,
     ),
 }
 

--- a/src/scenario_parameter_collection/detection.py
+++ b/src/scenario_parameter_collection/detection.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Iterable, List, Mapping, Sequence, Tuple
 import numpy as np
 import pandas as pd
 
+from .catalog import SCENARIO_DEFINITIONS
 from .utils import find_boolean_segments
 
 
@@ -55,6 +56,14 @@ class DetectionResult:
         if self.total_frames == 0:
             return 0.0
         return self.covered_frames() / self.total_frames
+
+    def scenario_counts(self) -> Dict[str, int]:
+        """Return the number of occurrences per detected scenario."""
+
+        counts: Dict[str, int] = {}
+        for event in self.events:
+            counts[event.scenario] = counts.get(event.scenario, 0) + 1
+        return counts
 
 
 def _default_parameter_extractor(window: pd.DataFrame, frame_rate: float) -> Dict[str, float]:
@@ -363,128 +372,27 @@ class HighDScenarioDetector:
         return events
 
     def _scenario_patterns(self) -> Sequence[ScenarioPattern]:
-        return (
-            ScenarioPattern(
-                name="free_driving",
-                required_tags=("tag_lane_keep", "tag_free_flow", "tag_speed_high"),
-                any_tags=("tag_lon_cruising", "tag_lon_accelerating"),
-                min_duration_s=2.0,
-                parameter_fn=PARAMETER_FUNCTIONS["free_driving"],
-            ),
-            ScenarioPattern(
-                name="free_acceleration",
-                required_tags=("tag_free_flow", "tag_lon_accelerating"),
-                forbidden_tags=("tag_lead_present",),
-                min_duration_s=1.2,
-                parameter_fn=PARAMETER_FUNCTIONS["free_acceleration"],
-            ),
-            ScenarioPattern(
-                name="free_deceleration",
-                required_tags=("tag_free_flow", "tag_lon_decelerating"),
-                forbidden_tags=("tag_lead_present",),
-                min_duration_s=1.2,
-                parameter_fn=PARAMETER_FUNCTIONS["free_deceleration"],
-            ),
-            ScenarioPattern(
-                name="car_following",
-                required_tags=("tag_lead_present", "tag_following_medium", "tag_lane_keep"),
-                forbidden_tags=("tag_following_close",),
-                min_duration_s=1.5,
-                parameter_fn=PARAMETER_FUNCTIONS["car_following"],
-            ),
-            ScenarioPattern(
-                name="car_following_close",
-                required_tags=("tag_lead_present", "tag_following_close", "tag_lane_keep"),
-                min_duration_s=1.6,
-                parameter_fn=PARAMETER_FUNCTIONS["car_following_close"],
-            ),
-            ScenarioPattern(
-                name="approaching_lead_vehicle",
-                required_tags=("tag_lead_present", "tag_approaching_lead", "tag_lane_keep"),
-                forbidden_tags=("tag_lead_braking",),
-                min_duration_s=1.2,
-                parameter_fn=PARAMETER_FUNCTIONS["approaching_lead_vehicle"],
-            ),
-            ScenarioPattern(
-                name="lead_vehicle_braking",
-                required_tags=("tag_lead_present", "tag_lead_braking"),
-                min_duration_s=0.6,
-                parameter_fn=PARAMETER_FUNCTIONS["lead_vehicle_braking"],
-            ),
-            ScenarioPattern(
-                name="ego_braking",
-                required_tags=("tag_lon_decelerating",),
-                forbidden_tags=("tag_lead_braking",),
-                min_duration_s=0.8,
-                parameter_fn=PARAMETER_FUNCTIONS["ego_braking"],
-            ),
-            ScenarioPattern(
-                name="ego_emergency_braking",
-                required_tags=("tag_lon_hard_brake",),
-                min_duration_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["ego_emergency_braking"],
-            ),
-            ScenarioPattern(
-                name="cut_in_from_left",
-                required_tags=("tag_cut_in_left",),
-                min_duration_s=0.4,
-                expansion_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["cut_in_from_left"],
-            ),
-            ScenarioPattern(
-                name="cut_in_from_right",
-                required_tags=("tag_cut_in_right",),
-                min_duration_s=0.4,
-                expansion_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["cut_in_from_right"],
-            ),
-            ScenarioPattern(
-                name="cut_out_to_left",
-                required_tags=("tag_cut_out_left",),
-                min_duration_s=0.4,
-                expansion_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["cut_out_to_left"],
-            ),
-            ScenarioPattern(
-                name="cut_out_to_right",
-                required_tags=("tag_cut_out_right",),
-                min_duration_s=0.4,
-                expansion_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["cut_out_to_right"],
-            ),
-            ScenarioPattern(
-                name="ego_lane_change_left",
-                required_tags=("tag_lane_change_left",),
-                min_duration_s=1.0,
-                expansion_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["ego_lane_change_left"],
-            ),
-            ScenarioPattern(
-                name="ego_lane_change_right",
-                required_tags=("tag_lane_change_right",),
-                min_duration_s=1.0,
-                expansion_s=0.4,
-                parameter_fn=PARAMETER_FUNCTIONS["ego_lane_change_right"],
-            ),
-            ScenarioPattern(
-                name="slow_traffic",
-                required_tags=("tag_lead_present", "tag_slow_speed"),
-                min_duration_s=3.0,
-                parameter_fn=PARAMETER_FUNCTIONS["slow_traffic"],
-            ),
-            ScenarioPattern(
-                name="stationary_lead",
-                required_tags=("tag_lead_present", "tag_lead_stationary"),
-                min_duration_s=0.6,
-                parameter_fn=PARAMETER_FUNCTIONS["stationary_lead"],
-            ),
-            ScenarioPattern(
-                name="stop_and_go_start",
-                required_tags=("tag_lead_present", "tag_stop_and_go"),
-                min_duration_s=1.0,
-                parameter_fn=PARAMETER_FUNCTIONS["stop_and_go_start"],
-            ),
-        )
+        patterns: List[ScenarioPattern] = []
+        for definition in SCENARIO_DEFINITIONS.values():
+            if not definition.tag_combination:
+                continue
+            combo = definition.tag_combination
+            required = tuple(combo.get("required", ()))
+            any_tags = tuple(combo.get("any", ()))
+            forbidden = tuple(combo.get("forbidden", ()))
+            parameter_fn = PARAMETER_FUNCTIONS.get(definition.name)
+            patterns.append(
+                ScenarioPattern(
+                    name=definition.name,
+                    required_tags=required,
+                    any_tags=any_tags,
+                    forbidden_tags=forbidden,
+                    min_duration_s=definition.min_duration_s,
+                    expansion_s=definition.expansion_s,
+                    parameter_fn=parameter_fn,
+                )
+            )
+        return patterns
 
     # ------------------------------------------------------------------
     # tag computation and pattern matching


### PR DESCRIPTION
## Summary
- add duration and expansion metadata to each HighD scenario definition so tag-based combinations encode pattern timing
- rebuild HighD scenario detector patterns directly from the catalog definitions and expose a helper to summarise scenario counts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9fcf512c88326ac148b2f52498fbf